### PR TITLE
被写体が縦に伸びることを修正

### DIFF
--- a/lib/screens/ar_camera_screen.dart
+++ b/lib/screens/ar_camera_screen.dart
@@ -55,9 +55,16 @@ class _ARCameraScreenState extends State<ARCameraScreen> {
     }
 
     // カメラ映像をフルスクリーンで表示
+    // 被写体が縦に伸びて表示されてしまう理由は、CameraPreview を SizedBox.expand を使って画面全体に強制的に引き伸ばしているからだった
     return Scaffold(
       backgroundColor: Colors.black,
-      body: SizedBox.expand(child: CameraPreview(_controller)),
+      body: Center(
+        child: AspectRatio(
+          // カメラのアスペクト比に合わせて表示枠を決定する（縦画面の場合は 1 / aspectRatio）
+          aspectRatio: 1 / _controller.value.aspectRatio,
+          child: CameraPreview(_controller),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## 事前チェック
- [x] 自分を Assignee に設定した
- [x] 関連 Issue を紐づけた（例: `Closes #123`）
- [x] 記載した Issue 番号が正しいことを確認した
- [x] PR の内容が関連 Issue の目的と一致している

## 概要
<!-- PR(pull request)の背景・目的・概要 -->
カメラを起動して被写体を写した時に縦に伸びていた。

## 関連タスク
<!-- 関連するIssue(todo)などを記載する -->


## やったこと
<!-- このPRで何をしたのか？ -->
```
return Scaffold(
      backgroundColor: Colors.black,
      body: Center(
        child: AspectRatio(
          // カメラのアスペクト比に合わせて表示枠を決定する（縦画面の場合は 1 / aspectRatio）
          aspectRatio: 1 / _controller.value.aspectRatio,
          child: CameraPreview(_controller),
        ),
      ),
    );
```
上記のように書いた。

<details>

<summary>詳細</summary>
被写体が縦に伸びて表示されてしまう理由は、CameraPreview を SizedBox.expand を使って画面全体に強制的に引き伸ばしているからです。

スマートフォンの画面のアスペクト比（縦横比）と、カメラが取得している映像のアスペクト比（今回設定されている ResolutionPreset.high は一般的に16:9や4:3）が異なるため、画面サイズに合わせて無理やり引き伸ばされることで映像が歪んで（縦や横に伸びて）しまいます。

これを修正して正しい比率で表示するには、カメラのアスペクト比を保ちつつ画面にフィットさせる必要があります。

アスペクト比を維持しつつできるだけ全画面に表示する一般的な方法は以下のようになります。


</details>


## 注意点
<!-- このissueを反映することで後に発生する可能性がある注意点を記載する -->



## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
