### PR TITLE
#2 reo

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,6 +1,4 @@
-# Uncomment this line to define a global platform for your project
-# platform :ios, '13.0'
-
+platform :ios, '15.5'
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,21 +2,128 @@ PODS:
   - camera_avfoundation (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - google_mlkit_commons (0.11.1):
+    - Flutter
+    - MLKitVision (~> 10.0.0)
+  - google_mlkit_pose_detection (0.14.1):
+    - Flutter
+    - google_mlkit_commons
+    - GoogleMLKit/PoseDetection (~> 9.0.0)
+    - GoogleMLKit/PoseDetectionAccurate (~> 9.0.0)
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleMLKit/MLKitCore (9.0.0):
+    - MLKitCommon (~> 14.0.0)
+  - GoogleMLKit/PoseDetection (9.0.0):
+    - GoogleMLKit/MLKitCore
+    - MLKitPoseDetection (~> 1.0.0-beta16)
+  - GoogleMLKit/PoseDetectionAccurate (9.0.0):
+    - GoogleMLKit/MLKitCore
+    - MLKitPoseDetectionAccurate (~> 1.0.0-beta16)
+  - GoogleToolboxForMac/Defines (4.2.1)
+  - GoogleToolboxForMac/Logger (4.2.1):
+    - GoogleToolboxForMac/Defines (= 4.2.1)
+  - "GoogleToolboxForMac/NSData+zlib (4.2.1)":
+    - GoogleToolboxForMac/Defines (= 4.2.1)
+  - GoogleUtilities/Environment (8.1.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/UserDefaults (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GTMSessionFetcher/Core (3.5.0)
+  - MLImage (1.0.0-beta8)
+  - MLKitCommon (14.0.0):
+    - GoogleDataTransport (~> 10.0)
+    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
+    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
+    - GoogleUtilities/Logger (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
+  - MLKitPoseDetection (1.0.0-beta16):
+    - MLKitCommon (~> 14.0)
+    - MLKitPoseDetectionCommon (= 1.0.0-beta16)
+    - MLKitXenoCommon (= 1.0.0-beta16)
+  - MLKitPoseDetectionAccurate (1.0.0-beta16):
+    - MLKitCommon (~> 14.0)
+    - MLKitPoseDetectionCommon (= 1.0.0-beta16)
+    - MLKitXenoCommon (= 1.0.0-beta16)
+  - MLKitPoseDetectionCommon (1.0.0-beta16):
+    - MLKitCommon (~> 14.0)
+    - MLKitXenoCommon (= 1.0.0-beta16)
+  - MLKitVision (10.0.0):
+    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
+    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
+    - MLImage (= 1.0.0-beta8)
+    - MLKitCommon (~> 14.0)
+  - MLKitXenoCommon (1.0.0-beta16):
+    - MLKitCommon (~> 14.0)
+    - MLKitVision (~> 10.0)
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
+  - PromisesObjC (2.4.0)
 
 DEPENDENCIES:
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - Flutter (from `Flutter`)
+  - google_mlkit_commons (from `.symlinks/plugins/google_mlkit_commons/ios`)
+  - google_mlkit_pose_detection (from `.symlinks/plugins/google_mlkit_pose_detection/ios`)
+
+SPEC REPOS:
+  trunk:
+    - GoogleDataTransport
+    - GoogleMLKit
+    - GoogleToolboxForMac
+    - GoogleUtilities
+    - GTMSessionFetcher
+    - MLImage
+    - MLKitCommon
+    - MLKitPoseDetection
+    - MLKitPoseDetectionAccurate
+    - MLKitPoseDetectionCommon
+    - MLKitVision
+    - MLKitXenoCommon
+    - nanopb
+    - PromisesObjC
 
 EXTERNAL SOURCES:
   camera_avfoundation:
     :path: ".symlinks/plugins/camera_avfoundation/ios"
   Flutter:
     :path: Flutter
+  google_mlkit_commons:
+    :path: ".symlinks/plugins/google_mlkit_commons/ios"
+  google_mlkit_pose_detection:
+    :path: ".symlinks/plugins/google_mlkit_pose_detection/ios"
 
 SPEC CHECKSUMS:
   camera_avfoundation: 968a9a5323c79a99c166ad9d7866bfd2047b5a9b
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  google_mlkit_commons: a5e4ffae5bc59ea4c7b9025dc72cb6cb79dc1166
+  google_mlkit_pose_detection: 211eabf55f5ea8d6a9537fdade0a37148fc84d8b
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleMLKit: b1eee21a41c57704fe72483b15c85cb2c0cd7444
+  GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  MLImage: 0de5c6c2bf9e93b80ef752e2797f0836f03b58c0
+  MLKitCommon: 47d47b50a031d00db62f1b0efe5a1d8b09a3b2e6
+  MLKitPoseDetection: 037fc62d6ccdd5a63253d1f40f90a8120b0d9c61
+  MLKitPoseDetectionAccurate: 4b25c5447244db7e1d97963c4d6e4ebe612c2d88
+  MLKitPoseDetectionCommon: 4709eb53b8638f5bf87c1a0255ad8aa4db9ad460
+  MLKitVision: 39a5a812db83c4a0794445088e567f3631c11961
+  MLKitXenoCommon: 1a4268c1222a6043047af5bb9435028206c63287
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
 
-PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+PODFILE CHECKSUM: 94229b228ae4cf88e83c6b95e3baccb627adef2e
 
 COCOAPODS: 1.16.2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -36,6 +36,9 @@ PODS:
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - GTMSessionFetcher/Core (3.5.0)
+  - MediaPipeTasksCommon (0.10.21)
+  - MediaPipeTasksVision (0.10.21):
+    - MediaPipeTasksCommon (= 0.10.21)
   - MLImage (1.0.0-beta8)
   - MLKitCommon (14.0.0):
     - GoogleDataTransport (~> 10.0)
@@ -70,12 +73,17 @@ PODS:
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
   - PromisesObjC (2.4.0)
+  - thinksys_mediapipe_plugin (0.0.13):
+    - Flutter
+    - MediaPipeTasksCommon (~> 0.10.14)
+    - MediaPipeTasksVision (~> 0.10.14)
 
 DEPENDENCIES:
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - Flutter (from `Flutter`)
   - google_mlkit_commons (from `.symlinks/plugins/google_mlkit_commons/ios`)
   - google_mlkit_pose_detection (from `.symlinks/plugins/google_mlkit_pose_detection/ios`)
+  - thinksys_mediapipe_plugin (from `.symlinks/plugins/thinksys_mediapipe_plugin/ios`)
 
 SPEC REPOS:
   trunk:
@@ -84,6 +92,8 @@ SPEC REPOS:
     - GoogleToolboxForMac
     - GoogleUtilities
     - GTMSessionFetcher
+    - MediaPipeTasksCommon
+    - MediaPipeTasksVision
     - MLImage
     - MLKitCommon
     - MLKitPoseDetection
@@ -103,6 +113,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_mlkit_commons/ios"
   google_mlkit_pose_detection:
     :path: ".symlinks/plugins/google_mlkit_pose_detection/ios"
+  thinksys_mediapipe_plugin:
+    :path: ".symlinks/plugins/thinksys_mediapipe_plugin/ios"
 
 SPEC CHECKSUMS:
   camera_avfoundation: 968a9a5323c79a99c166ad9d7866bfd2047b5a9b
@@ -114,6 +126,8 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  MediaPipeTasksCommon: 6cfa29170d4900f04d250ad95ec058f14a741f38
+  MediaPipeTasksVision: 7b1c0f5a5820e87e9d96926f5e65d8cd3744fac2
   MLImage: 0de5c6c2bf9e93b80ef752e2797f0836f03b58c0
   MLKitCommon: 47d47b50a031d00db62f1b0efe5a1d8b09a3b2e6
   MLKitPoseDetection: 037fc62d6ccdd5a63253d1f40f90a8120b0d9c61
@@ -123,6 +137,7 @@ SPEC CHECKSUMS:
   MLKitXenoCommon: 1a4268c1222a6043047af5bb9435028206c63287
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  thinksys_mediapipe_plugin: d05edb8269ac727ece82375b249f86347a32a53a
 
 PODFILE CHECKSUM: 94229b228ae4cf88e83c6b95e3baccb627adef2e
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				C3FEB2E7596C0B9BEFCFC1FA /* [CP] Embed Pods Frameworks */,
+				4B28C83BD67D0A8B95E7300A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -287,6 +288,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		4B28C83BD67D0A8B95E7300A /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		5383D8237DB43190BCFD08B6 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:camera/camera.dart';
-import 'screens/ar_camera_screen.dart';
+// 元の画面は Bridge の中で使うので残しておきます
+import 'screens/ar_camera_screen.dart'; 
 
 Future<void> main() async {
-  // main関数内で非同期処理を呼び出すための設定
   WidgetsFlutterBinding.ensureInitialized();
-  // ↑iOS/Androidのカメラハードウェア）」にアクセスする前にいるおまじない
-
-  // デバイスで利用可能なカメラのリストを取得
+  // カメラのリストを取得
   final cameras = await availableCameras();
-
-  // 取得できているか確認
-  print(cameras);
 
   runApp(
     MaterialApp(
       debugShowCheckedModeBanner: false,
+     
       home: ARCameraScreen(cameras: cameras),
     ),
   );

--- a/lib/screens/ar_camera_screen.dart
+++ b/lib/screens/ar_camera_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:camera/camera.dart';
+import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
+import 'screen_recognize_skelton.dart';
 
 class ARCameraScreen extends StatefulWidget {
   final List<CameraDescription> cameras;
@@ -14,6 +16,10 @@ class _ARCameraScreenState extends State<ARCameraScreen> {
   late CameraController _controller;
   bool _isInitialized = false;
 
+  // ★ 配線1：箱から出して、いつでも使えるように準備する
+  final SkeletonRecognizer _recognizer = SkeletonRecognizer();
+  List<Pose> _detectedPoses = []; // 見つけた骨格データをメモする場所
+
   @override
   void initState() {
     super.initState();
@@ -21,17 +27,28 @@ class _ARCameraScreenState extends State<ARCameraScreen> {
     _controller = CameraController(
       widget.cameras[0],
       ResolutionPreset.high, // 画質は骨格検知のために高めに設定している
-    ); // cameras[0]はスマホの背面カメラを指す
+    ); 
     _controller
         .initialize()
         .then((_) {
           if (!mounted) return;
+
+          // ★ 配線2：カメラの映像（パラパラ漫画の1コマ）を、AIに渡し続ける
+          _controller.startImageStream((image) async {
+            final poses = await _recognizer.recognize(image, widget.cameras[0]);
+            
+            if (mounted && poses.isNotEmpty) {
+              setState(() {
+                _detectedPoses = poses; // AIが見つけた骨格をメモに上書きする
+              });
+              // 確認用：ターミナルに「33」とかの数字が出れば大成功！
+              debugPrint('見つけた関節の数: ${poses.first.landmarks.length}');
+            }
+          });
+
           setState(() {
             _isInitialized = true;
           });
-
-          // [Issue 1-2の伏線] 次のフェーズで、ここに以下のコードを追加します
-          // _controller.startImageStream((image) => processImageForPoseDetection(image));
         })
         .catchError((e) {
           debugPrint("Camera Error: $e");
@@ -40,6 +57,8 @@ class _ARCameraScreenState extends State<ARCameraScreen> {
 
   @override
   void dispose() {
+    // ★ 配線3：使い終わったらAIエンジンも片付ける
+    _recognizer.dispose();
     _controller.dispose();
     super.dispose();
   }
@@ -55,14 +74,29 @@ class _ARCameraScreenState extends State<ARCameraScreen> {
     }
 
     // カメラ映像をフルスクリーンで表示
-    // 被写体が縦に伸びて表示されてしまう理由は、CameraPreview を SizedBox.expand を使って画面全体に強制的に引き伸ばしているからだった
     return Scaffold(
       backgroundColor: Colors.black,
       body: Center(
         child: AspectRatio(
-          // カメラのアスペクト比に合わせて表示枠を決定する（縦画面の場合は 1 / aspectRatio）
+          // カメラのアスペクト比に合わせて表示枠を決定する
           aspectRatio: 1 / _controller.value.aspectRatio,
-          child: CameraPreview(_controller),
+          // ★ Stackを使ってカメラ映像の上にお絵かきキャンバスを重ねる
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              // 1枚目（下）：いつものカメラ映像
+              CameraPreview(_controller),
+              
+              // 2枚目（上）：AIが見つけた骨格の赤い点（お絵かき職人）
+              if (_detectedPoses.isNotEmpty)
+                CustomPaint(
+                  painter: PosePainter(
+                    _detectedPoses,
+                    _controller.value.previewSize!, // カメラの解像度を渡す
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/ar_camera_screen.dart
+++ b/lib/screens/ar_camera_screen.dart
@@ -17,9 +17,11 @@ class _ARCameraScreenState extends State<ARCameraScreen> {
   @override
   void initState() {
     super.initState();
-    // MVPやから、まずは一番目のカメラ（通常は背面カメラ）を決め打ちで初期化
-    _controller = CameraController(widget.cameras[0], ResolutionPreset.high);
-
+    // MVPやから、まずは一番目のカメラ（通常は背面カメラ）を決め打ちで初期化する
+    _controller = CameraController(
+      widget.cameras[0],
+      ResolutionPreset.high, // 画質は骨格検知のために高めに設定している
+    ); // cameras[0]はスマホの背面カメラを指す
     _controller
         .initialize()
         .then((_) {
@@ -53,9 +55,16 @@ class _ARCameraScreenState extends State<ARCameraScreen> {
     }
 
     // カメラ映像をフルスクリーンで表示
+    // 被写体が縦に伸びて表示されてしまう理由は、CameraPreview を SizedBox.expand を使って画面全体に強制的に引き伸ばしているからだった
     return Scaffold(
       backgroundColor: Colors.black,
-      body: SizedBox.expand(child: CameraPreview(_controller)),
+      body: Center(
+        child: AspectRatio(
+          // カメラのアスペクト比に合わせて表示枠を決定する（縦画面の場合は 1 / aspectRatio）
+          aspectRatio: 1 / _controller.value.aspectRatio,
+          child: CameraPreview(_controller),
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/pose_painter.dart
+++ b/lib/screens/pose_painter.dart
@@ -1,0 +1,40 @@
+// 新しく作るファイル：pose_painter.dart
+
+import 'package:flutter/material.dart';
+import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
+
+class PosePainter extends CustomPainter {
+  final List<Pose> poses;
+  final Size imageSize; // カメラ映像の元のサイズ
+
+  PosePainter(this.poses, this.imageSize);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // 筆の設定（赤い点で、少し太めに描く）
+    final paint = Paint()
+      ..style = PaintingStyle.fill
+      ..strokeWidth = 4.0
+      ..color = Colors.red;
+
+    for (final pose in poses) {
+      pose.landmarks.forEach((_, landmark) {
+        // 【重要】カメラの解像度と、スマホの画面サイズのズレを補正する計算
+        // これがないと、実際の体から赤い点がズレて表示されてしまいます
+        final double scaleX = size.width / imageSize.height;
+        final double scaleY = size.height / imageSize.width;
+
+        final double x = landmark.x * scaleX;
+        final double y = landmark.y * scaleY;
+
+        // 計算した正しい位置に、半径5.0の丸を描く
+        canvas.drawCircle(Offset(x, y), 5.0, paint);
+      });
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant PosePainter oldDelegate) {
+    return true; // 人が動くたびに、点を描き直す
+  }
+}

--- a/lib/screens/screen_recognize_skelton.dart
+++ b/lib/screens/screen_recognize_skelton.dart
@@ -1,0 +1,63 @@
+import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
+import 'package:camera/camera.dart';
+import 'package:flutter/services.dart';
+export 'pose_painter.dart';
+class SkeletonRecognizer {
+  // MediaPipe (BlazePose) の高精度エンジンを初期化
+  final PoseDetector _poseDetector = PoseDetector(
+    options: PoseDetectorOptions(
+      model: PoseDetectionModel.accurate, // ここでMediaPipeのHeavyモデルを指定
+      mode: PoseDetectionMode.stream,
+    ),
+  );
+
+  bool _isBusy = false;
+
+  /// カメラ映像を解析して、検出された骨格(Pose)のリストを返す
+  Future<List<Pose>> recognize(CameraImage image, CameraDescription camera) async {
+    // 処理中に新しいフレームが来たらスキップ（パフォーマンス確保）
+    if (_isBusy) return [];
+    _isBusy = true;
+
+    try {
+      final inputImage = _convertToInputImage(image, camera);
+      final poses = await _poseDetector.processImage(inputImage);
+      return poses;
+    } catch (e) {
+      print('骨格検出エラー: $e');
+      return [];
+    } finally {
+      _isBusy = false;
+    }
+  }
+
+  /// CameraImageをML Kitが読める形式に変換する内部メソッド
+  InputImage _convertToInputImage(CameraImage image, CameraDescription camera) {
+    final WriteBuffer allBytes = WriteBuffer();
+    for (final Plane plane in image.planes) {
+      allBytes.putUint8List(plane.bytes);
+    }
+    final bytes = allBytes.done().buffer.asUint8List();
+
+    // デバイスの向き（90度など）をMediaPipeに伝える
+    final imageRotation = InputImageRotationValue.fromRawValue(camera.sensorOrientation) 
+                          ?? InputImageRotation.rotation0deg;
+    
+    final inputImageFormat = InputImageFormatValue.fromRawValue(image.format.raw) 
+                             ?? InputImageFormat.bgra8888;
+
+    final inputImageData = InputImageMetadata(
+      size: Size(image.width.toDouble(), image.height.toDouble()),
+      rotation: imageRotation,
+      format: inputImageFormat,
+      bytesPerRow: image.planes[0].bytesPerRow,
+    );
+
+    return InputImage.fromBytes(bytes: bytes, metadata: inputImageData);
+  }
+
+  /// メモリ解放
+  void dispose() {
+    _poseDetector.close();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -176,6 +176,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_mlkit_commons:
+    dependency: transitive
+    description:
+      name: google_mlkit_commons
+      sha256: "3e69fea4211727732cc385104e675ad1e40b29f12edd492ee52fa108423a6124"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.1"
+  google_mlkit_pose_detection:
+    dependency: "direct main"
+    description:
+      name: google_mlkit_pose_detection
+      sha256: "9157847e41fff1703b6b16b1af5508cf5def85cad96b7b724394fa9fe386cb8f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.14.1"
   hooks:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -421,6 +429,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  thinksys_mediapipe_plugin:
+    dependency: "direct main"
+    description:
+      name: thinksys_mediapipe_plugin
+      sha256: "59ba31d8b420d5d5a1cac9ee2b1d667e766b7bf72b815eceeee25eea4ff17d9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.13"
   typed_data:
     dependency: transitive
     description:
@@ -449,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   path_provider: ^2.1.5
   path: ^1.9.1
   google_mlkit_pose_detection: ^0.14.1
+  thinksys_mediapipe_plugin: ^0.0.13
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   camera: ^0.12.0
   path_provider: ^2.1.5
   path: ^1.9.1
+  google_mlkit_pose_detection: ^0.14.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 事前チェック
- [x] 自分を Assignee に設定した
- [x] 関連 Issue を紐づけた（例: `Closes #123`）
- [x] 記載した Issue 番号が正しいことを確認した
- [x] PR の内容が関連 Issue の目的と一致している

## 概要
<!-- PR(pull request)の背景・目的・概要 -->
骨格の検出と表示

## 関連タスク
<!-- 関連するIssue(todo)などを記載する -->


## やったこと
<!-- このPRで何をしたのか？ -->

<details>

<summary>詳細</summary>

関連ファイルを確認します。   

[](file:///Users/reoguku0423/gdgoc_hackathon_2026/lib/screens/ar_camera_screen.dart#1-1) の 1 から 100 行を読み取り

[](file:///Users/reoguku0423/gdgoc_hackathon_2026/lib/screens/pose_painter.dart) の読み取り

[](file:///Users/reoguku0423/gdgoc_hackathon_2026/lib/screens/screen_recognize_skelton.dart) の読み取り

[](file:///Users/reoguku0423/gdgoc_hackathon_2026/pubspec.yaml#1-1) の 1 から 50 行を読み取り

このプロジェクトで骨格検出と表示を実現するために行われた変更・実装内容を詳しく説明します。

---

## 1. 依存パッケージの追加（pubspec.yaml）

```yaml
camera: ^0.12.0
google_mlkit_pose_detection: ^0.14.1
thinksys_mediapipe_plugin: ^0.0.13
```

- **`camera`**: スマートフォンのカメラにアクセスし、リアルタイムの映像フレームを取得するために追加
- **`google_mlkit_pose_detection`**: Google の ML Kit（内部は MediaPipe/BlazePose）を使って骨格を検出するために追加

---

## 2. 骨格検出エンジン（screen_recognize_skelton.dart）の新規作成

**役割：カメラ映像 → ML Kit が読める形式に変換 → AIで骨格検出**

主な実装内容：

| 実装 | 内容 |
|------|------|
| `PoseDetector` の初期化 | `PoseDetectionModel.accurate`（MediaPipe重量モデル）と`stream`モードで高精度リアルタイム検出 |
| `recognize()` メソッド | `CameraImage`を受け取り`List<Pose>`を返す。`_isBusy`フラグでフレームスキップしパフォーマンスを確保 |
| `_convertToInputImage()` | `CameraImage`のバイト列をML Kitの`InputImage`に変換。カメラのセンサー向き・画像フォーマット・解像度も正しく設定 |
| `dispose()` | `_poseDetector.close()`でメモリを解放 |

---

## 3. 骨格描画クラス（pose_painter.dart）の新規作成

**役割：検出した関節座標をカメラ映像の上に赤い点として描画**

主な実装内容：

| 実装 | 内容 |
|------|------|
| `CustomPainter`を継承 | Flutterの描画APIを使ってキャンバスに直接描く |
| 座標スケール補正 | カメラの元解像度（例：1920×1080）とスマホ画面サイズ（例：390×844）が異なるため、`scaleX = size.width / imageSize.height`などで補正。**これがないと関節の点が体からズレる** |
| `drawCircle()` | 各関節に半径5.0・赤色の円を描画 |
| `shouldRepaint()`が`true` | 人が動くたびに毎フレーム再描画 |

---

## 4. カメラ画面（ar_camera_screen.dart）の実装

**役割：カメラ映像＋骨格検出＋描画を統合**

主な実装内容：

| 実装 | 内容 |
|------|------|
| `SkeletonRecognizer`のインスタンス化 | `_recognizer`として保持し、カメラフレームの解析に使う |
| `startImageStream()`で毎フレーム解析 | カメラの各フレームを`_recognizer.recognize()`に渡し、戻ってきた`List<Pose>`を`setState()`で`_detectedPoses`に保存 |
| `Stack`で重ねて表示 | `CameraPreview`（カメラ映像）の上に`CustomPaint(painter: PosePainter(...))`を重ね、ARっぽく表示 |
| `AspectRatio`でフルスクリーン表示 | カメラのアスペクト比に合わせて正しい縦横比で表示 |
| `dispose()`で後片付け | `_recognizer.dispose()`と`_controller.dispose()`を呼び出しメモリリーク防止 |

---

## 全体のデータフロー

```
カメラ映像（毎フレーム）
    ↓ startImageStream()
CameraImage（生データ）
    ↓ _convertToInputImage()（screen_recognize_skelton.dart）
InputImage（ML Kit形式）
    ↓ _poseDetector.processImage()
List<Pose>（関節座標33点）
    ↓ setState() で _detectedPoses に保存
CustomPaint → PosePainter（pose_painter.dart）
    ↓ 座標補正 + drawCircle()
カメラ映像の上に赤い点をリアルタイム表示
```

---

## 5. エントリーポイント（main.dart）の修正

`availableCameras()`でカメラ一覧を取得し、`ARCameraScreen(cameras: cameras)`に渡すだけのシンプルな構成にした。

</details>


## 注意点
<!-- このissueを反映することで後に発生する可能性がある注意点を記載する -->



## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
