### PR TITLE
Googleログイン機能の追加とユーザー情報の保存

### DIFF
--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -12,7 +12,20 @@
           "package_name": "com.example.gdgoc_hackathon_2026"
         }
       },
-      "oauth_client": [],
+      "oauth_client": [
+        {
+          "client_id": "15024072966-hrr4as9129idm13pb1mfg90o6fofqrl8.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.example.gdgoc_hackathon_2026",
+            "certificate_hash": "7d523a507eb98ed420160cc197ab0e7cfa41b826"
+          }
+        },
+        {
+          "client_id": "15024072966-h0ifgnhnumlukvaln4q1dvo5867lls9u.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
       "api_key": [
         {
           "current_key": "AIzaSyD6JQ4tiRR051ExK_W8KdYqdnCpFKDy75M"
@@ -20,7 +33,19 @@
       ],
       "services": {
         "appinvite_service": {
-          "other_platform_oauth_client": []
+          "other_platform_oauth_client": [
+            {
+              "client_id": "15024072966-h0ifgnhnumlukvaln4q1dvo5867lls9u.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "15024072966-8rjbdgk2lm8ob44nebdm886v35h43r6o.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.example.gdgocHackathon2026"
+              }
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
## 事前チェック
- [x] 自分を Assignee に設定した
- [x] 関連 Issue を紐づけた（例: `Closes #123`）
- [x] 記載した Issue 番号が正しいことを確認した
- [x] PR の内容が関連 Issue の目的と一致している

## 概要
<!-- PR(pull request)の背景・目的・概要 -->
- 匿名認証からGoogleサインインへ変更 (`google_sign_in` パッケージ追加)
- 起動画面を `SignInDemo` へ変更し、認証成功後に `PoseDetectorView` へ遷移するよう修正
- ログイン成功時、ユーザーのメールアドレスをハッシュ化(SHA-256)して Firestore の `users/{uid}` に保存する処理を追加
- Android/iOS の Google Sign-In 設定ファイル (`google-services.json`, `GoogleService-Info.plist`, `Info.plist`) を更新
- Firestoreのセキュリティルールを更新 (書き込み権限を `request.auth.uid == userId` に制限)

## 関連タスク
<!-- 関連するIssue(todo)などを記載する -->


## やったこと
<!-- このPRで何をしたのか？ -->
<details>

<summary>1. 起動直後のクラッシュ原因の特定とアーキテクチャ修正</summary>
初期状態: アプリ起動時に裏側で行っていた「匿名ログイン」が失敗し、画面（UI）を描画する前にアプリがクラッシュして止まっていました。
行ったこと: 画面を描画する前（runApp()より前）にログイン処理を強制するのをやめました。アプリの起動画面（エントリーポイント）を SignInDemo というログイン専用画面に変更し、UIをしっかり表示してから認証を行う安全な流れに変えました。
</details>

<details>

<summary>2. Google Sign-In の導入と設定不整合（エラー10）の解消</summary>
- 初期状態: 最初はメール・パスワード方式を試しましたが、最終的に「Googleログイン」を採用しました。
- 行ったこと:
[pubspec.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) に google_sign_in: ^6.2.1 を追加しました（最初は最新のv7系を入れてエラーが出たため、コードに合わせたv6系に調整しました）。
実行時に ApiException: 10 (設定エラー) が発生しました。これはFirebaseとGoogle Cloud側に手元のAndroidの「SHA-1（署名鍵）」が登録されていないことが原因でした。
SHA-1をFirebaseに登録し、最新の [google-services.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Android) や GoogleService-Info.plist / Info.plist (iOS) をダウンロードしてプロジェクトに適用することで、無事にGoogleログインが通るようになりました。
</details>

<details>

<summary>メールアドレスの暗号化（ハッシュ化）とFirestoreへの保存</summary>

要件: 認証完了後、ユーザーのメールアドレスを直接保存するのではなく、ハッシュ化して安全に保存してからカメラ画面へ遷移したい。
行ったこと:
[pubspec.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) に crypto パッケージを追加しました。
[main.dart](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) を修正し、「Googleログイン成功」→「メールアドレスを小文字変換して空白排除（正規化）」→「SHA-256でハッシュ化」という処理を実装しました。
ハッシュ化したアドレスとプロバイダ情報（Google）を、Firestoreの users/{uid} に保存（マージ上書き）する仕組みを追加しました。
データの保存が完全に成功した直後に限って、AIポーズ検出画面（PoseDetectorView）へ遷移する堅牢な画面遷移に変えました。コンパイルエラー（使っていないimportや戻り値のズレ）もすべて綺麗に掃除しています。
4
</details>

<details>

<summary>Firestoreのセキュリティルール（権限）の強化</summary>
- 初期状態: Firestoreへ保存しようとしたところ permission-denied（権限エラー）が発生しました。手元の設定ファイルはゆるい設定になっていましたが、Firebaseサーバー側のルールが厳しくて弾かれていました。
- 行ったこと:
セキュリティルールを「ログインさえしていれば全データを読み書きできる」という一時的なものから、「自分（uid）のドキュメントにしか書き込みできない」 という本番でも通用する安全な設計へ書き直しました。

```
match /users/{userId} {
  allow read: if request.auth != null;
  allow write: if request.auth != null && request.auth.uid == userId;
}
```

</details>


## 注意点
<!-- このissueを反映することで後に発生する可能性がある注意点を記載する -->



## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
