### PR TITLE
服のAR合成時の逆さま描画、顔が隠れる位置ズレ、サイズ感を修正

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,5 +12,11 @@ service cloud.firestore {
       allow write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // clothesコレクションのルール
+    match /clothes/{document=**} {
+      allow read: if true; // テストのため一旦誰でも（あるいは if request.auth != null;）
+      allow write: if false;
+    }
+
     // 今後他のコレクション（例: posts）を作る場合、それらにはアクセスさせない（デフォルト拒否）
   }

--- a/lib/vision_detector_views/painters/clothes_painter.dart
+++ b/lib/vision_detector_views/painters/clothes_painter.dart
@@ -1,0 +1,123 @@
+import 'dart:math';
+import 'dart:ui' as ui;
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
+import 'coordinates_translator.dart';
+
+class ClothesPainter extends CustomPainter {
+  final List<Pose> poses;
+  final Size imageSize;
+  final InputImageRotation rotation;
+  final CameraLensDirection cameraLensDirection;
+  final ui.Image clothesImage;
+  final num clothesBaseShoulderWidthPx;
+
+  ClothesPainter(
+    this.poses,
+    this.imageSize,
+    this.rotation,
+    this.cameraLensDirection,
+    this.clothesImage,
+    this.clothesBaseShoulderWidthPx,
+  );
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (poses.isEmpty) return;
+
+    final pose = poses.first;
+    final leftShoulder = pose.landmarks[PoseLandmarkType.leftShoulder];
+    final rightShoulder = pose.landmarks[PoseLandmarkType.rightShoulder];
+
+    if (leftShoulder != null && rightShoulder != null) {
+      // ステップ2: 解像度ズレの補正 (画面座標への変換)
+      final leftX = translateX(
+        leftShoulder.x,
+        size,
+        imageSize,
+        rotation,
+        cameraLensDirection,
+      );
+      final leftY = translateY(
+        leftShoulder.y,
+        size,
+        imageSize,
+        rotation,
+        cameraLensDirection,
+      );
+      final rightX = translateX(
+        rightShoulder.x,
+        size,
+        imageSize,
+        rotation,
+        cameraLensDirection,
+      );
+      final rightY = translateY(
+        rightShoulder.y,
+        size,
+        imageSize,
+        rotation,
+        cameraLensDirection,
+      );
+
+      // ステップ3: 服の配置基準点「ネックライン」の算出
+      final centerX = (leftX + rightX) / 2;
+      // 首の付け根の高さに合わせる（以前は上にオフセットしていましたが、顔が隠れる原因になるため基準をそのまま使用）
+      final centerY = (leftY + rightY) / 2;
+
+      // ステップ4: 肩幅ピクセル距離と動的スケールの計算
+      double dx = rightX - leftX;
+      double dy = rightY - leftY;
+
+      // フロントカメラ鏡面反射等で左右が反転している場合の補正（上下逆さま防止）
+      if (leftX > rightX) {
+        dx = leftX - rightX;
+        dy = leftY - rightY;
+      }
+
+      final shoulderDistance = sqrt(dx * dx + dy * dy);
+
+      // 服画像の本来の幅に対するスケール比率
+      // baseShoulderWidthPx が0より大きければその値を使用、なければ画像幅で代用
+      final baseWidth = clothesBaseShoulderWidthPx > 0
+          ? clothesBaseShoulderWidthPx
+          : clothesImage.width;
+
+      // 骨格サイズ(関節間)と服の全体のサイズのギャップを埋めるための倍率補正
+      // 2.2の部分を画面に合わせて調整してください
+      final double scaleMultiplier = 0.7; // 服の見た目の大きさを調整するための定数
+      final scale = (shoulderDistance / baseWidth) * scaleMultiplier;
+
+      // ステップ5: ユーザーの傾きへの追従計算 (回転角)
+      final angle = atan2(dy, dx);
+
+      // ステップ6: 描画
+      canvas.save();
+      canvas.translate(centerX, centerY);
+      if (cameraLensDirection == CameraLensDirection.front) {
+        // フロントカメラの場合は鏡のように反転しているので、左右の角度と画像を合わせる調整が必要な場合があります。
+        // 今回は単純な傾き反映
+        canvas.rotate(angle);
+      } else {
+        canvas.rotate(angle);
+      }
+
+      canvas.scale(scale);
+
+      // 画像の襟元が肩の高さに来るように、Y軸のオフセットを調整する
+      // -clothesImage.height / 2 (中心) から、上から15%程度の位置に変更
+      double neckOffsetY = clothesImage.height * 0.15;
+
+      canvas.drawImage(
+        clothesImage,
+        Offset(-clothesImage.width / 2, -neckOffsetY),
+        Paint(),
+      );
+      canvas.restore();
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant ClothesPainter oldDelegate) => true;
+}

--- a/lib/vision_detector_views/pose_detector_view.dart
+++ b/lib/vision_detector_views/pose_detector_view.dart
@@ -7,9 +7,12 @@ import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
 import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'dart:ui' as ui;
+import 'dart:async';
 
 import 'detector_view.dart';
 import 'painters/pose_painter.dart';
+import 'painters/clothes_painter.dart';
 
 class PoseDetectorView extends StatefulWidget {
   final bool isFirstLogin;
@@ -38,6 +41,11 @@ class _PoseDetectorViewState extends State<PoseDetectorView> {
 
   // 服の検索が完了したかどうかのフラグ
   bool _isClothesReady = false;
+
+  // ARで表示する服の画像
+  ui.Image? _clothesImage;
+  // 選択された服のデータ
+  Clothes? _selectedClothes;
 
   @override
   void dispose() async {
@@ -179,7 +187,19 @@ class _PoseDetectorViewState extends State<PoseDetectorView> {
         _text = _statusMessage;
       } else {
         // [状態3] 準備完了：取得した服の画像を描画 (ClothesPainterなどを新設する)
-        _customPaint = null; // <- 将来的に ClothesPainter に差し替える部分
+        if (_clothesImage != null && _selectedClothes != null) {
+          final painter = ClothesPainter(
+            poses,
+            inputImage.metadata!.size,
+            inputImage.metadata!.rotation,
+            _cameraLensDirection,
+            _clothesImage!,
+            _selectedClothes!.baseShoulderWidthPx,
+          );
+          _customPaint = CustomPaint(painter: painter);
+        } else {
+          _customPaint = null;
+        }
         _text = "";
       }
     } else {
@@ -204,8 +224,29 @@ class _PoseDetectorViewState extends State<PoseDetectorView> {
           .map((doc) => Clothes.fromFirestore(doc))
           .toList();
 
+      print("🔥 Firestoreから服を ${clothesList.length} 件取得しました");
+
+      String imageUrl = "";
+      if (clothesList.isNotEmpty) {
+        // 服を選ぶ（今回は一番目の服、もしくはサイズが最も近い服など）
+        // ここでは簡単に最初の服を選択
+        _selectedClothes = clothesList.first;
+        if (_selectedClothes!.imageUrl.isNotEmpty) {
+          imageUrl = _selectedClothes!.imageUrl;
+          print("👕 服の画像URL: $imageUrl");
+        } else {
+          throw Exception("服の画像URLが空です");
+        }
+      } else {
+        throw Exception("Firestoreに服のデータが存在しません");
+      }
+
+      // 画像をダウンロードして ui.Image に変換
+      final image = await _loadImageFromUrl(imageUrl);
+
       if (mounted) {
         setState(() {
+          _clothesImage = image;
           _isClothesReady = true;
           _statusMessage = "服の準備が完了しました！";
         });
@@ -213,6 +254,7 @@ class _PoseDetectorViewState extends State<PoseDetectorView> {
         print("📱現在のステータス: $_statusMessage");
       }
     } catch (e) {
+      print("服の取得エラー: $e");
       if (mounted) {
         setState(() {
           _statusMessage = "服の取得に失敗しました。";
@@ -220,16 +262,56 @@ class _PoseDetectorViewState extends State<PoseDetectorView> {
       }
     }
   }
+
+  Future<ui.Image> _loadImageFromUrl(String url) async {
+    final ImageStream stream = NetworkImage(
+      url,
+    ).resolve(ImageConfiguration.empty);
+    final Completer<ui.Image> completer = Completer();
+    late ImageStreamListener listener;
+    listener = ImageStreamListener(
+      (ImageInfo info, bool synchronousCall) {
+        if (!completer.isCompleted) {
+          completer.complete(info.image);
+        }
+        stream.removeListener(listener);
+      },
+      onError: (dynamic exception, StackTrace? stackTrace) {
+        if (!completer.isCompleted) {
+          completer.completeError(exception);
+        }
+        stream.removeListener(listener);
+      },
+    );
+    stream.addListener(listener);
+    return completer.future;
+  }
 }
 
 // 簡易的な服のデータモデルクラス（エラー回避のためのダミー実装です。実際の実装に合わせて調整してください）
 class Clothes {
   final String id;
-  // TODO: 実際のFirestoreのフィールド構造に合わせてプロパティを追加してください
+  final String imageUrl;
+  final String itemName;
+  final String brandName;
+  final num baseShoulderWidthPx;
 
-  Clothes({required this.id});
+  Clothes({
+    required this.id,
+    this.imageUrl = "",
+    this.itemName = "",
+    this.brandName = "",
+    this.baseShoulderWidthPx = 0,
+  });
 
   factory Clothes.fromFirestore(DocumentSnapshot doc) {
-    return Clothes(id: doc.id);
+    final data = doc.data() as Map<String, dynamic>?;
+    return Clothes(
+      id: doc.id,
+      imageUrl: data?['imageUrl'] ?? "",
+      itemName: data?['itemName'] ?? "",
+      brandName: data?['brandName'] ?? "",
+      baseShoulderWidthPx: data?['baseShoulderWidthPx'] ?? 0,
+    );
   }
 }


### PR DESCRIPTION
## 事前チェック
- [x] 自分を Assignee に設定した
- [x] 関連 Issue を紐づけた（例: `Closes #123`）
- [x] 記載した Issue 番号が正しいことを確認した
- [x] PR の内容が関連 Issue の目的と一致している

## 概要
<!-- PR(pull request)の背景・目的・概要 -->
- 上下反転問題の修正
フロントカメラ等の鏡面反射時などで左右の肩座標（leftX, rightX）が反転している場合、角度を算出するためのベクトル（dx, dy）の計算順を補正し、180度ズレて逆さまになるのを防止しました。
- 服の描画位置（高さ）のズレ修正
これまで画像の「中心（高さの50%位置）」を肩のラインに合わせていたため、服全体が上方向にズレて顔を覆ってしまっていました。これを、画像の「襟元（上から15%前後の位置）」を基準に描画するようY軸のオフセット（neckOffsetY）を導入・修正しました。
- 服の表示サイズの調整機構の追加
検出された肩幅の距離と画像幅の比率に対して、表示倍率を微調整できる scaleMultiplier 変数を導入しました。（現在は 0.8 前後で調整中）

## 関連タスク
<!-- 関連するIssue(todo)などを記載する -->


## やったこと
<!-- このPRで何をしたのか？ -->



## 注意点
<!-- このissueを反映することで後に発生する可能性がある注意点を記載する -->



## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
